### PR TITLE
NP-2364 unified-logging returns a list of responses in search method

### DIFF
--- a/unified-logging/entities.proto
+++ b/unified-logging/entities.proto
@@ -55,10 +55,21 @@ message ExpirationRequest{
     string app_instance_id = 2;
 }
 
-// LogResponse message containing the results of a query.
-message LogResponse{
+
+// LogResponseList message with a list of LogResponses
+message LogResponseList {
     // OrganizationId with the organization identifier.
     string organization_id = 1;
+    // From with the minimal timestamp of the returned results.
+    int64 from = 2;
+    // To with the maximum timestamp of the returned results.
+    int64 to = 3;
+    // Responses with a list of log responses
+    repeated LogResponse responses = 4;
+}
+
+// LogResponse message containing the results of a query.
+message LogResponse{
     // AppDescriptorId with the descriptor identifier
     string app_descriptor_id = 2;
     // AppInstanceId with the identifier of the target application instance.
@@ -71,10 +82,6 @@ message LogResponse{
     string service_id = 6;
     // ServiceInstanceId with the service instance identifier
     string service_instance_id = 7;
-    // From with the minimal timestamp of the returned results.
-    int64 from = 8;
-    // To with the maximum timestamp of the returned results.
-    int64 to = 9;
     // Entries with the captured log entries.
     repeated LogEntry entries = 10;
 }

--- a/unified-logging/services.proto
+++ b/unified-logging/services.proto
@@ -26,7 +26,7 @@ import "common/entities.proto";
 // Coordinator service with the operations offered by the query coordinator.
 service Coordinator {
     // Search for log entries matching a query.
-    rpc Search(SearchRequest) returns (LogResponse) {}
+    rpc Search(SearchRequest) returns (LogResponseList) {}
     // Expire the logs of a given application.
     rpc Expire(ExpirationRequest) returns(common.Success) {}
 }
@@ -34,7 +34,7 @@ service Coordinator {
 // Slave services for localling retrieving a set of logs.
 service Slave {
     // Search for log entries matching a query.
-    rpc Search(SearchRequest) returns(LogResponse) {}
+    rpc Search(SearchRequest) returns(LogResponseList) {}
     // Expire the logs of a given application.
     rpc Expire(ExpirationRequest) returns(common.Success) {}
 }


### PR DESCRIPTION
#### What does this PR do?
update unified-logging to return a list of responses in Search
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?
Elastic returns a list of messages of different services

#### What are the relevant tickets?

- [NP-2364](https://nalej.atlassian.net/browse/NP-2364)

#### Screenshots (if appropriate)

#### Questions
