### PR TITLE
NP-2364 k8s_id_query_filter added in SearchRequest

### DIFF
--- a/unified-logging/entities.proto
+++ b/unified-logging/entities.proto
@@ -21,6 +21,7 @@ package unified_logging;
 option go_package = "github.com/nalej/grpc-unified-logging-go";
 import "google/protobuf/timestamp.proto";
 
+
 // SearchRequest message with the query to be resolved.
 message SearchRequest{
     // OrganizationId with the organization identifier.
@@ -38,13 +39,20 @@ message SearchRequest{
     string service_id = 6;
     // ServiceInstanceId with the service instance identifier
     string service_instance_id = 7;
+    // k8sIdQueryFilter contains a map associating kubernetes labels with possible ids that should be matched with an OR.
+    map<string, IdsList> k8s_id_query_filter = 8;
     // MsgQueryFilter contains a text query on the log entry.
-    string msg_query_filter = 8;
+    string msg_query_filter = 9;
     // From specifies the minimal timestamp of the expected entries.
-    int64 from = 9;
+    int64 from = 10;
     // To specifies the maximum timestamp of the expected entries.
-    int64 to = 10;
+    int64 to = 11;
 
+}
+
+message IdsList {
+    // Ids with a list of identifiers
+    repeated string ids = 1;
 }
 
 // ExpirationRequest to remove entries from the index.

--- a/unified-logging/entities.proto
+++ b/unified-logging/entities.proto
@@ -40,7 +40,7 @@ message SearchRequest{
     // ServiceInstanceId with the service instance identifier
     string service_instance_id = 7;
     // k8sIdQueryFilter contains a map associating kubernetes labels with possible ids that should be matched with an OR.
-    map<string, IdsList> k8s_id_query_filter = 8;
+    map<string, IdList> k8s_id_query_filter = 8;
     // MsgQueryFilter contains a text query on the log entry.
     string msg_query_filter = 9;
     // From specifies the minimal timestamp of the expected entries.
@@ -50,7 +50,7 @@ message SearchRequest{
 
 }
 
-message IdsList {
+message IdList {
     // Ids with a list of identifiers
     repeated string ids = 1;
 }


### PR DESCRIPTION
#### What does this PR do?
k8s_id_query_filter added in unified_logging.SearchRequest

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?
The `msg_query_filter` must be applied in the log message and all the possible names. In k8s_id_query_filter we introduce the Kubernetes label and the possible identifiers than satisfy this filter

#### What are the relevant tickets?

- [NP-2364](https://nalej.atlassian.net/browse/NP-2364)

#### Screenshots (if appropriate)

#### Questions
