### PR TITLE
NP-2432 failedClusterIds added

### DIFF
--- a/unified-logging/entities.proto
+++ b/unified-logging/entities.proto
@@ -67,6 +67,8 @@ message LogResponseList {
     int64 to = 3;
     // Responses with a list of log responses
     repeated LogResponse responses = 4;
+    // FailedClusterIds with a list og cluster identifiers whose call failed
+    repeated string failed_cluster_ids = 5;
 }
 
 // LogResponse message containing the results of a query.


### PR DESCRIPTION
#### What does this PR do?
- includes failed_cluster_ids in unified-logging LogResponseList

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?
If one of the unified-logging slaves fails  the user needs to know the query is not completed and which cluster has failed
#### What are the relevant tickets?

- [NP-2432](https://nalej.atlassian.net/browse/NP-2432)

#### Screenshots (if appropriate)

#### Questions
