### PR TITLE
NP-2388 New method for public-api.

### DIFF
--- a/public-api/services.proto
+++ b/public-api/services.proto
@@ -612,4 +612,10 @@ service Monitoring {
             get: "/v1/monitoring/{organization_id}/cluster/{cluster_id}/summary"
         };
     }
+    // GetOrganizationApplicationStats retrieves an aggregated organization stats grouped by serviceInstance.
+    rpc GetOrganizationApplicationStats(monitoring.OrganizationApplicationStatsRequest) returns (monitoring.OrganizationApplicationStatsResponse) {
+        option (google.api.http) = {
+            get: "/v1/monitoring/{organization_id}/stats"
+        };
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
Adds the new method `GetOrganizationApplicationStats` to the public-api/monitoring RPCs.

#### What are the relevant tickets?

- [NP-2388](https://nalej.atlassian.net/browse/NP-2388)
- [NP-2368](https://nalej.atlassian.net/browse/NP-2368)
