### PR TITLE
NP-2498 nFirst field added in SearchRequest message

### DIFF
--- a/application-manager/entities.proto
+++ b/application-manager/entities.proto
@@ -219,6 +219,9 @@ message SearchRequest {
     int64 to = 10;
     // IncludeMetadata  flag to indicate if the result should not be augmented by adding names, etc.
     bool include_metadata = 11;
+    // NFirst is a flag that identifies whether the user expects to receive the first n results or not
+    // if the search must be sorted ascending or descending
+    bool n_first = 12;
 }
 
 // LogResponse message containing the results of a query.

--- a/unified-logging/entities.proto
+++ b/unified-logging/entities.proto
@@ -45,6 +45,9 @@ message SearchRequest{
     int64 from = 9;
     // To specifies the maximum timestamp of the expected entries.
     int64 to = 10;
+    // NFirst is a flag that identifies whether the user expects to receive the first n results or not
+    // if the search must be sorted ascending or descending
+    bool n_first = 11;
 
 }
 


### PR DESCRIPTION
#### What does this PR do?
Updates SearchRequest to add `nFirst` field. This field is a flag that identifies whether the user expects to receive the first n results or not 
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2498](https://nalej.atlassian.net/browse/NP-2498)

#### Screenshots (if appropriate)

#### Questions
