### PR TITLE
NP-2498 NFirst field added in public_api.SearchRequest

### DIFF
--- a/public-api/entities.proto
+++ b/public-api/entities.proto
@@ -850,5 +850,7 @@ message SearchRequest {
     int64 to = 10;
     // Order specifies the sort order of the entries (on timestamp)
     OrderOptions order = 11;
+    // NFirst is a flag that identifies whether the user expects to receive the first n results or not
+    bool n_first = 12;
 }
 


### PR DESCRIPTION
#### What does this PR do?
Include `NFirst` field.
When the number of results is greater than the limit, this field indicates if the user wishes to receive the first or last

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2498](https://nalej.atlassian.net/browse/NP-2498)

#### Screenshots (if appropriate)

#### Questions
