### PR TITLE
NP-2508 List DownloadLogResponse added

### DIFF
--- a/log-download-manager/entities.proto
+++ b/log-download-manager/entities.proto
@@ -55,7 +55,8 @@ enum DownloadLogState{
     QUEUED = 0;
     GENERATING = 1;
     READY = 2;
-    ERROR = 3;
+    DOWNLOADED = 3;
+    ERROR = 4;
 }
 
 // DownloadLogResponse with a response of a download/check operation
@@ -76,6 +77,12 @@ message DownloadLogResponse {
     int64 expiration = 7;
     // Info contains additional information on the status of the operation
     string info = 8;
+}
+
+//DownloadLogResponseList with a list of responses
+message DownloadLogResponseList {
+    // responses with a list of responses
+    repeated DownloadLogResponse responses = 1;
 }
 
 // DownloadRequestId contains the identifier of an operation

--- a/log-download-manager/services.proto
+++ b/log-download-manager/services.proto
@@ -22,6 +22,7 @@ option go_package = "github.com/nalej/grpc-log-download-manager-go";
 
 import "common/entities.proto";
 import "log-download-manager/entities.proto";
+import "organization/entities.proto";
 
 service LogDownloadManager {
     // DownloadLog asks for a logs download operation. These logs are going to be stored in a zip file
@@ -29,5 +30,5 @@ service LogDownloadManager {
     // Check asks for a download operation state
     rpc Check (DownloadRequestId) returns (DownloadLogResponse) {}
     // List retrieves a list of responses
-    rpc List (DownloadRequestId) returns (DownloadLogResponseList) {}
+    rpc List (organization.OrganizationId) returns (DownloadLogResponseList) {}
 }

--- a/log-download-manager/services.proto
+++ b/log-download-manager/services.proto
@@ -25,7 +25,9 @@ import "log-download-manager/entities.proto";
 
 service LogDownloadManager {
     // DownloadLog asks for a logs download operation. These logs are going to be stored in a zip file
-    rpc DownloadLog(DownloadLogRequest) returns (DownloadLogResponse) {}
+    rpc DownloadLog (DownloadLogRequest) returns (DownloadLogResponse) {}
     // Check asks for a download operation state
-    rpc Check(DownloadRequestId) returns (DownloadLogResponse) {}
+    rpc Check (DownloadRequestId) returns (DownloadLogResponse) {}
+    // List retrieves a list of responses
+    rpc List (DownloadRequestId) returns (DownloadLogResponseList) {}
 }

--- a/public-api/entities.proto
+++ b/public-api/entities.proto
@@ -876,3 +876,9 @@ message DownloadLogResponse {
     // Info contains additional information on the status of the operation
     string info = 9;
 }
+
+// DownloadLogResponse with a list of DownloadLogResponses
+message DownloadLogResponseList {
+    // DownloadLogResponse list of responses
+    repeated DownloadLogResponse responses = 1;
+}

--- a/public-api/services.proto
+++ b/public-api/services.proto
@@ -437,7 +437,7 @@ service UnifiedLogging{
         };
     }
     // List retrieve a list of requests
-    rpc List(log_download_manager.DownloadRequestId) returns (DownloadLogResponseList) {
+    rpc List(organization.OrganizationId) returns (DownloadLogResponseList) {
         option (google.api.http) = {
             get: "/v1/log/{organization_id}/download/list"
         };

--- a/public-api/services.proto
+++ b/public-api/services.proto
@@ -423,13 +423,6 @@ service UnifiedLogging{
             body: "*"
         };
     }
-    // Check checks the state of the download operation
-    rpc Check(log_download_manager.DownloadRequestId) returns (DownloadLogResponse) {
-        option (google.api.http) = {
-            post: "/v1/log/{organization_id}/check"
-            body: "*"
-        };
-    }
     // DownloadLog ask for log entries and store them into a zip file
     rpc DownloadLog(log_download_manager.DownloadLogRequest) returns (DownloadLogResponse) {
         option (google.api.http) = {
@@ -437,6 +430,19 @@ service UnifiedLogging{
             body: "*"
         };
     }
+    // Check checks the state of the download operation
+    rpc Check(log_download_manager.DownloadRequestId) returns (DownloadLogResponse) {
+        option (google.api.http) = {
+            get: "/v1/log/{organization_id}/download/{request_id}/check"
+        };
+    }
+    // List retrieve a list of requests
+    rpc List(log_download_manager.DownloadRequestId) returns (DownloadLogResponseList) {
+        option (google.api.http) = {
+            get: "/v1/log/{organization_id}/download/list"
+        };
+    }
+
 }
 
 // EdgeControllers related operations.


### PR DESCRIPTION
#### What does this PR do?
- add a method to list all the DownloadLogResponses
- add new DownloadLogState: `DOWNLOADED`

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2508](https://nalej.atlassian.net/browse/NP-2508)

#### Screenshots (if appropriate)

#### Questions
